### PR TITLE
fix: enforce password length of at least 6 chars in UI form validation

### DIFF
--- a/apps/next/components/user/register-form.tsx
+++ b/apps/next/components/user/register-form.tsx
@@ -57,7 +57,7 @@ export const RegisterForm: React.FC = () => {
 
 const FormSchema = z.object({
   email: z.string().email({ message: "Invalid email address" }),
-  password: z.string().min(5, { message: "Must be 5 or more characters long" }),
+  password: z.string().min(6, { message: "Must be 6 or more characters long" }),
 })
 
 const RegisterFormComponent: React.FC<{


### PR DESCRIPTION
<!---
**IMPORTANT**:

Please do not create a Pull Request without creating an issue first. A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/iamhectorsosa/supabase-modules/pulls) before creating one.

For more information, see the [`CONTRIBUTING`(https://github.com/iamhectorsosa/supabase-modules/blob/main/CONTRIBUTING.md) guide.

-->

## Summary

This PR  fixes following **bugs**:

-  #24 - password validation mismatch in DB and in UI

## Testing

1. Go to Create new account
2. Submit details with password exactly 5 chars long
3. Hit Create Account
4. The UI should show validation error message saying that the password needs to be at least 6 chars long


## Related issues
closes #24