### PR TITLE
fix: wrong link passed to redirect option on credentials update

### DIFF
--- a/apps/next/components/user/credentials-form.tsx
+++ b/apps/next/components/user/credentials-form.tsx
@@ -54,7 +54,7 @@ export const CredentialsForm: React.FC<{ userEmail: string }> = ({
           email,
           password,
           redirect: {
-            url: "/accounts/credentials",
+            url: "/settings/credentials",
           },
         })
       }}


### PR DESCRIPTION
<!---
**IMPORTANT**:

Please do not create a Pull Request without creating an issue first. A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/iamhectorsosa/supabase-modules/pulls) before creating one.

For more information, see the [`CONTRIBUTING`(https://github.com/iamhectorsosa/supabase-modules/blob/main/CONTRIBUTING.md) guide.

-->

## Summary

This PR fixes following **bugs**:

- #27 - wrong link passed to redirect option in Credentials settings

## Testing

1. Go to Credentials settings
2. Change something
3. Submit
4. No 404 page should be displayed


## Related issues

closes #27