### PR TITLE
feat: Email change should trigger update on profiles table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules
+**/cache/
 
 # Turbo
 .turbo

--- a/apps/next/components/ui/dialog.tsx
+++ b/apps/next/components/ui/dialog.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { Cross2Icon } from "@radix-ui/react-icons"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {}
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  DialogContentProps
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className="fixed z-50 flex h-screen w-screen items-center justify-center"
+      {...props}
+    >
+      <div
+        className={cn(
+          "relative rounded-lg border border-gray-100 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+          className
+        )}
+      >
+        <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <Cross2Icon className="size-5" />
+        </DialogClose>
+        {children}
+      </div>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+const DialogHeader = ({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("w-full pr-6", className)} {...props}>
+    <DialogTitle>{children}</DialogTitle>
+  </div>
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/apps/next/components/user/credentials-form.tsx
+++ b/apps/next/components/user/credentials-form.tsx
@@ -30,6 +30,14 @@ import { Input } from "@/components/ui/input"
 
 import { updateUser } from "@/modules/user/auth"
 
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+} from "../ui/dialog"
+
 export const CredentialsForm: React.FC<{ userEmail: string }> = ({
   userEmail,
 }) => {
@@ -82,6 +90,9 @@ const CredentialsFormComponent: React.FC<{
   isError: boolean
   errorMessage?: string
 }> = ({ userEmail, updateUser, isPending, isError, errorMessage }) => {
+  const [isEmailChangeInfoDialogOpen, setEmailChangeInfoDialogOpen] =
+    React.useState(false)
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
@@ -102,7 +113,10 @@ const CredentialsFormComponent: React.FC<{
             onSubmit={form.handleSubmit(({ email, password }) => {
               const updates: { email?: string; password?: string } = {}
 
-              if (email) updates.email = email
+              if (email) {
+                updates.email = email
+                setEmailChangeInfoDialogOpen(true)
+              }
               if (password) updates.password = password
 
               if (Object.keys(updates).length > 0) {
@@ -159,6 +173,29 @@ const CredentialsFormComponent: React.FC<{
             </Button>
           </form>
         </Form>
+        <Dialog
+          open={isEmailChangeInfoDialogOpen}
+          onOpenChange={setEmailChangeInfoDialogOpen}
+        >
+          <DialogContent className="flex max-w-[480px] flex-col gap-4">
+            <DialogHeader>Email change needs to be confirmed</DialogHeader>
+            <DialogDescription>
+              In order to successfully change the email this need to be
+              confirmed for <b>both</b> email addresses. The confirmation links
+              have been sent to your new and your old email address. Please
+              check your inbox and follow the instructions to confirm the
+              change.
+            </DialogDescription>
+            <DialogFooter>
+              <Button
+                variant="secondary"
+                onClick={() => setEmailChangeInfoDialogOpen(false)}
+              >
+                Close
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </CardContent>
     </Card>
   )

--- a/apps/next/components/user/credentials-form.tsx
+++ b/apps/next/components/user/credentials-form.tsx
@@ -18,6 +18,13 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+} from "@/components/ui/dialog"
+import {
   Form,
   FormControl,
   FormDescription,
@@ -29,14 +36,6 @@ import {
 import { Input } from "@/components/ui/input"
 
 import { updateUser } from "@/modules/user/auth"
-
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-} from "../ui/dialog"
 
 export const CredentialsForm: React.FC<{ userEmail: string }> = ({
   userEmail,

--- a/apps/next/modules/user/migrations.sql
+++ b/apps/next/modules/user/migrations.sql
@@ -41,6 +41,19 @@ AS $function$BEGIN
 END;$function$
 ;
 
+CREATE OR REPLACE FUNCTION public.update_user_email()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$BEGIN
+  UPDATE public.profiles 
+  SET email = NEW.email
+  WHERE id = NEW.id;
+
+  RETURN NEW;
+END;$function$
+;
+
 grant delete on table "public"."profiles" to "anon";
 
 grant insert on table "public"."profiles" to "anon";
@@ -117,3 +130,7 @@ with check ((auth.uid() = id));
 
 
 CREATE TRIGGER handle_new_user_trigger AFTER INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+
+CREATE TRIGGER update_email_in_profiles_trigger AFTER UPDATE OF email ON auth.users FOR EACH ROW EXECUTE FUNCTION update_user_email();
+
+

--- a/apps/next/supabase/migrations/20240422112854_user.sql
+++ b/apps/next/supabase/migrations/20240422112854_user.sql
@@ -1,0 +1,16 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.update_user_email()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$BEGIN
+  UPDATE public.profiles 
+  SET email = NEW.email
+  WHERE id = NEW.id;
+
+  RETURN NEW;
+END;$function$
+;
+
+

--- a/apps/next/supabase/migrations/20240422114557_user.sql
+++ b/apps/next/supabase/migrations/20240422114557_user.sql
@@ -1,0 +1,3 @@
+CREATE TRIGGER update_email_in_profiles_trigger AFTER UPDATE OF email ON auth.users FOR EACH ROW EXECUTE FUNCTION update_user_email();
+
+


### PR DESCRIPTION
<!---
**IMPORTANT**:

Please do not create a Pull Request without creating an issue first. A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/iamhectorsosa/supabase-modules/pulls) before creating one.

For more information, see the [`CONTRIBUTING`(https://github.com/iamhectorsosa/supabase-modules/blob/main/CONTRIBUTING.md) guide.

-->

## Summary

This PR implements / improves the following **features**:
  - new Dialog UI component
  - informing user about need to confirm email change in both inboxes

and fixes the following **bugs**:
- #8 - new DB function and trigger for the function that will handle email change in `profiles` table on auth.users` table row change

## Testing
1. Go to Credentials settings and submit the user email change
2. The dialog alert should be shown
3. In the Credentials form there is still old email address shown at this point
4. Follow the instructions (confirm the email in the both inboxes)
5. Check Credentials settings - email should be changed to new 


## Related issues

<!---
Put _closes #XXXX_ in your comment to auto-close the issue that your PR implements.
-->

closes #8 
